### PR TITLE
Deprecate Go SDK

### DIFF
--- a/smartcar.go
+++ b/smartcar.go
@@ -1,6 +1,8 @@
 // Package smartcar is the official Go SDK of the Smartcar API.
 // Smartcar is the only vehicle API built for developers, by developers.
 // Learn more about Smartcar here, https://smartcar.com/
+//
+// Deprecated: This package is no longer maintained. Please migrate to an alternative solution.
 package smartcar
 
 import (


### PR DESCRIPTION
After publishing this version pkg.go.dev should pick it up and mark it as deprecated